### PR TITLE
Upgrade to Wordpress 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         }
     ],
     "require": {
-        "johnpbloch/wordpress": "4.9.*",
+        "johnpbloch/wordpress": "5.2.*",
         "wpackagist-plugin/add-meta-tags": "2.*",
         "wpackagist-plugin/akismet": "3.*",
         "wpackagist-plugin/blog-copier": "1.*",


### PR DESCRIPTION
I've started testing this locally, seems to run mostly fine.

Release notes:

- https://wordpress.org/news/2018/12/bebo/
- https://wordpress.org/news/2019/02/betty/
- https://wordpress.org/news/2019/05/jaco/

Issues discovered so far:

- [x] The plugin "vimeo quicktag" is not loaded in the editor. Proposing to simply remove it, can be done with the new video functionality of Wordpress. However some migration for the existing [vimeo] tags would need to be done.
